### PR TITLE
fix: 移动端宽度在某些情况下会撑得很大 #77

### DIFF
--- a/src/components/docs-flow/docs-flow.svelte
+++ b/src/components/docs-flow/docs-flow.svelte
@@ -244,6 +244,9 @@
 <style lang="scss">
 
     .docs-flow {
+        @media (max-width: 767px) {
+            width: 100vw;
+        }
         :global(div.docs-flow__protyle .protyle-breadcrumb) {
             display: var(--display-breadcrumb);
         }


### PR DESCRIPTION
加前：
<img width="603" height="1311" alt="IMG_1976" src="https://github.com/user-attachments/assets/f3636ee4-aae2-4a60-8a18-e3293eec7a3c" />

加后：
<img width="603" height="1311" alt="IMG_1975" src="https://github.com/user-attachments/assets/4af01a00-ac54-4eaa-b005-e655e9c75c8e" />
