### PR TITLE
update: 一些情况下获取到的id不存在块

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,6 +24,7 @@ export const firstPara2Parent = async (ids: BlockId[]): Promise<BlockId[]> => {
     for (let id of ids) {
         result.push(id);
         let info = data[id];
+        if (!info) continue;
         if (info.type !== 'NodeParagraph') continue;
         if (info.previousID !== '') continue;
         if (!['NodeBlockquote', 'NodeListItem'].includes(info.parentType)) continue;


### PR DESCRIPTION
有时候因为数据问题id不能获取到块（此时重建索引能解决），导致空指针不能展示文档流。这里加下判断。